### PR TITLE
Fix run_emulator_pullback for batched (matrix) inputs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,10 @@
 name = "AbstractCosmologicalEmulators"
 uuid = "c83c1981-e5c4-4837-9eb8-c9b1572acfc6"
-version = "0.10.0"
-authors = ["Marco Bonici <bonici.marco@gmail.com>"]
+version = "0.10.1"
+authors = [
+    "Marco Bonici <bonici.marco@gmail.com>",
+    "Sofia Chiarenza <schiarenza@uwaterloo.ca>",
+]
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/README.md
+++ b/README.md
@@ -114,4 +114,4 @@ Stable API | :construction: | Work in progress
 ## Authors
 
 - [Marco Bonici](https://www.marcobonici.com), PostDoctoral Researcher at Waterloo Centre for Astrophysics
-- [Marius Millea](https://cosmicmar.com), Researcher at UC Davis and Berkeley Center for Cosmological Physics
+- Sofia Chiarenza, PhD Student at Waterloo Centre for Astrophysics

--- a/ext/MooncakeExt/MooncakeExt.jl
+++ b/ext/MooncakeExt/MooncakeExt.jl
@@ -69,7 +69,7 @@ function ChainRulesCore.rrule(::typeof(AbstractCosmologicalEmulators.run_emulato
         vjp_input = convert(typeof(input), ForwardDiff.gradient(
             x -> begin
                 y_dual, _ = Lux.apply(emulator.Model, x, emulator.Parameters, emulator.States)
-                sum(y_dual .* Δy_vec)
+                sum(vec(y_dual) .* Δy_vec)
             end,
             input
         ))

--- a/test/test_lux_emulator_autodiff.jl
+++ b/test/test_lux_emulator_autodiff.jl
@@ -101,6 +101,38 @@ using Mooncake
 
                 println("✅ Mooncake gradient (LuxEmulator): SUCCESS")
             end
+
+            @testset "Gradient computation with batched matrix input" begin
+                batched_input = Float32[
+                    0.1 0.4
+                    0.2 0.5
+                    0.3 0.6
+                ]
+
+                function batched_loss(input)
+                    result = run_emulator(input, lux_emu)
+                    return sum(result .^ 2)
+                end
+
+                result = run_emulator(batched_input, lux_emu)
+                @test size(result) == (n_output, size(batched_input, 2))
+
+                grad_mk = DifferentiationInterface.gradient(
+                    batched_loss,
+                    AutoMooncake(; config=Mooncake.Config()),
+                    batched_input
+                )
+
+                @test size(grad_mk) == size(batched_input)
+                @test all(isfinite.(grad_mk))
+
+                # Regression test for the matrix-output pullback: the Mooncake rule
+                # should compute the same input VJP as direct ForwardDiff/Zygote.
+                grad_fd = ForwardDiff.gradient(batched_loss, batched_input)
+                grad_zy = Zygote.gradient(batched_loss, batched_input)[1]
+                @test grad_mk ≈ grad_fd rtol=1e-6
+                @test grad_mk ≈ grad_zy rtol=1e-6
+            end
         end
     end
 


### PR DESCRIPTION
## Bug

When `run_emulator` is called with a batched matrix input of shape
`(n_features, n_z)` (as Mapse does, stacking all redshift points into
one matrix), `Lux.apply` returns a matrix `(n_k, n_z)`.

In `run_emulator_pullback`, the adjoint `Δy` has the same shape and is
flattened via `vec()` to length `n_k * n_z`. The broadcast:

    sum(y_dual .* Δy_vec)   # (n_k, n_z) .* (n_k*n_z,)

fails with a `DimensionMismatch` because Julia compares the first
dimension of the 2-D array (`n_k`) against the 1-D vector length
(`n_k * n_z`).

## Fix

Flatten `y_dual` before the multiply so both operands are 1-D:

    sum(vec(y_dual) .* Δy_vec)

## Tested

Verified with NUTS + Mooncake on a 3×2pt LSST-Y10 likelihood using
Mapse (batched emulator calls over ~50 redshift points).
